### PR TITLE
Feat: 인기 메뉴 TOP5, 하위 메뉴 TOP5 데모 데이터 사용해서 구현

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const baseURL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const baseURL = import.meta.env.VITE_API_URL;
 
 export const api = axios.create({
   baseURL,

--- a/src/api/menuService.ts
+++ b/src/api/menuService.ts
@@ -1,0 +1,54 @@
+import { instance } from './axios';
+import { MenuRankingResponse, RankingPeriod } from '../interface/menu';
+
+// 데모 데이터
+const MOCK_DATA: Record<RankingPeriod, MenuRankingResponse> = {
+  weekly: {
+    topRankings: [
+      { id: 1, name: '김치찌개', score: 4.8, rankChange: 2 },
+      { id: 2, name: '비빔밥', score: 4.7, rankChange: -1 },
+      { id: 3, name: '돈까스', score: 4.6, rankChange: 1 },
+      { id: 4, name: '된장찌개', score: 4.5, rankChange: 0 },
+      { id: 5, name: '불고기', score: 4.4, rankChange: -2 },
+    ],
+    bottomRankings: [
+      { id: 6, name: '공나물국', score: 2.1, rankChange: -3 },
+      { id: 7, name: '오징어볶음', score: 2.3, rankChange: 1 },
+      { id: 8, name: '김치볶음밥', score: 2.5, rankChange: 0 },
+      { id: 9, name: '우동', score: 2.7, rankChange: 2 },
+      { id: 10, name: '아채죽', score: 2.8, rankChange: -1 },
+    ],
+    period: 'weekly',
+  },
+  monthly: {
+    topRankings: [
+      { id: 1, name: '삼겹살', score: 4.9, rankChange: 3 },
+      { id: 2, name: '치킨', score: 4.8, rankChange: -1 },
+      { id: 3, name: '피자', score: 4.7, rankChange: 2 },
+      { id: 4, name: '라면', score: 4.6, rankChange: -2 },
+      { id: 5, name: '떡볶이', score: 4.5, rankChange: 1 },
+    ],
+    bottomRankings: [
+      { id: 6, name: '청국장', score: 2.0, rankChange: -2 },
+      { id: 7, name: '순대국', score: 2.2, rankChange: 1 },
+      { id: 8, name: '콩나물국밥', score: 2.4, rankChange: 0 },
+      { id: 9, name: '미역국', score: 2.6, rankChange: -1 },
+      { id: 10, name: '북엇국', score: 2.8, rankChange: 2 },
+    ],
+    period: 'monthly',
+  },
+};
+
+export const getMenuRankings = async (period: RankingPeriod): Promise<MenuRankingResponse> => {
+  // const response = await api.get('/api/menuRanking', {
+  //   params: { period },
+  // });
+  // return response.data;
+
+  // 데모 데이터
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(MOCK_DATA[period]);
+    }, 500);
+  });
+};

--- a/src/components/ranking/RankingList.tsx
+++ b/src/components/ranking/RankingList.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import styled from 'styled-components';
+import { MenuRankingItem, RankingType } from '../interface/menu';
+
+interface RankingListProps {
+  title: string;
+  items: MenuRankingItem[];
+  type: RankingType;
+}
+
+const RankingList = ({ title, items, type }: RankingListProps) => {
+  return (
+    <RankingSection>
+      <RankingTitle>{title}</RankingTitle>
+      <RankingListContainer>
+        {items.map((item, index) => (
+          <RankingItem key={item.id}>
+            <Rank>{index + 1}</Rank>
+            <MenuName>{item.name}</MenuName>
+            <Score>{item.score.toFixed(1)}점</Score>
+            <RankChange change={item.rankChange}>
+              {item.rankChange > 0
+                ? `▲${item.rankChange}`
+                : item.rankChange < 0
+                  ? `▼${Math.abs(item.rankChange)}`
+                  : '-'}
+            </RankChange>
+          </RankingItem>
+        ))}
+      </RankingListContainer>
+    </RankingSection>
+  );
+};
+
+const RankingSection = styled.div`
+  flex: 1;
+  min-width: 300px;
+`;
+
+const RankingTitle = styled.h2`
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+  color: ${(props) => props.theme.colors.primary};
+`;
+
+const RankingListContainer = styled.div`
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+`;
+
+const RankingItem = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid #eee;
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const Rank = styled.span`
+  font-weight: bold;
+  width: 40px;
+`;
+
+const MenuName = styled.span`
+  flex: 1;
+`;
+
+const Score = styled.span`
+  margin: 0 1rem;
+  color: #666;
+`;
+
+const RankChange = styled.span<{ change: number }>`
+  color: ${(props) => (props.change > 0 ? '#f00' : props.change < 0 ? '#00f' : '#666')};
+  width: 50px;
+  text-align: right;
+`;
+
+export default RankingList;

--- a/src/interface/menu.ts
+++ b/src/interface/menu.ts
@@ -1,0 +1,16 @@
+export interface MenuRankingItem {
+  id: number;
+  name: string;
+  score: number;
+  rankChange: number; // 순위 변동
+}
+
+export type RankingPeriod = 'weekly' | 'monthly';
+
+export type RankingType = 'top' | 'bottom';
+
+export interface MenuRankingResponse {
+  topRankings: MenuRankingItem[];
+  bottomRankings: MenuRankingItem[];
+  period: RankingPeriod;
+}

--- a/src/pages/MenuRanking.tsx
+++ b/src/pages/MenuRanking.tsx
@@ -1,16 +1,98 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { getMenuRankings } from '../api/menuService';
+import { MenuRankingItem, RankingPeriod } from '../interface/menu';
+import RankingList from '../components/ranking/RankingList';
 
 const MenuRanking = () => {
+  const [period, setPeriod] = useState<RankingPeriod>('weekly');
+  const [topRankings, setTopRankings] = useState<MenuRankingItem[]>([]);
+  const [bottomRankings, setBottomRankings] = useState<MenuRankingItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchRankings = async () => {
+      setLoading(true);
+      try {
+        const response = await getMenuRankings(period);
+        setTopRankings(response.topRankings);
+        setBottomRankings(response.bottomRankings);
+      } catch (error) {
+        console.error('랭킹 데이터를 불러오는데 실패했습니다:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRankings();
+  }, [period]);
+
   return (
     <MenuRankingContainer>
-      <h1>메뉴 랭킹</h1>
+      <RankingHeader>
+        <h1>메뉴 랭킹</h1>
+        <PeriodToggle>
+          <ToggleButton active={period === 'weekly'} onClick={() => setPeriod('weekly')}>
+            주간
+          </ToggleButton>
+          <ToggleButton active={period === 'monthly'} onClick={() => setPeriod('monthly')}>
+            월간
+          </ToggleButton>
+        </PeriodToggle>
+      </RankingHeader>
+
+      {loading ? (
+        <LoadingText>로딩 중...</LoadingText>
+      ) : (
+        <RankingsContainer>
+          <RankingList title="인기 메뉴 TOP 5" items={topRankings} type="top" />
+          <RankingList title="하위 메뉴 TOP 5" items={bottomRankings} type="bottom" />
+        </RankingsContainer>
+      )}
     </MenuRankingContainer>
   );
 };
 
 const MenuRankingContainer = styled.div`
   padding: ${({ theme }) => theme.spacing.lg};
+  max-width: 1200px;
+  margin: 0 auto;
+`;
+
+const RankingHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+`;
+
+const PeriodToggle = styled.div`
+  display: flex;
+  background: #f0f0f0;
+  border-radius: 20px;
+  padding: 4px;
+`;
+
+const ToggleButton = styled.button<{ active: boolean }>`
+  padding: 8px 16px;
+  border-radius: 16px;
+  border: none;
+  background: ${(props) => (props.active ? '#fff' : 'transparent')};
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: ${(props) => (props.active ? '0 2px 4px rgba(0,0,0,0.1)' : 'none')};
+`;
+
+const RankingsContainer = styled.div`
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+`;
+
+const LoadingText = styled.div`
+  text-align: center;
+  padding: 2rem;
+  color: #666;
 `;
 
 export default MenuRanking;


### PR DESCRIPTION
### 📝작업 내용

> 인기 메뉴 TOP5, 하위 메뉴 TOP5 데모 데이터 사용해서 구현
- components/ranking/RankingLisg.tsx를 사용해서 메뉴 인기/하위 TOP5 구현했습니다.
- 오른쪽 상단의 주간/월간 버튼을 클릭하면 TOP5 메뉴가 바뀌는 기능을 구현했습니다.
- 데모 데이터를 사용해서 interface/menu.ts, api/menuService.ts를 구현했습니다.
- menu.ts는 interface, menuService.ts는 api 통신에 필요한 함수를 구현했습니다.

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1440" alt="스크린샷 2025-03-28 오후 6 21 04" src="https://github.com/user-attachments/assets/75a6d5d7-390f-4dc6-b2f0-797d8c09b9ba" />

<img width="1440" alt="스크린샷 2025-03-28 오후 6 21 09" src="https://github.com/user-attachments/assets/28858ae8-60a2-495a-a4ea-5a04899b3509" />
