### PR TITLE
Fix: 데모데이터 삭제 후 /api/menu/rank api 연결

### DIFF
--- a/src/api/menuService.ts
+++ b/src/api/menuService.ts
@@ -1,54 +1,9 @@
-import { instance } from './axios';
+import { api } from './axios';
 import { MenuRankingResponse, RankingPeriod } from '../interface/menu';
 
-// 데모 데이터
-const MOCK_DATA: Record<RankingPeriod, MenuRankingResponse> = {
-  weekly: {
-    topRankings: [
-      { id: 1, name: '김치찌개', score: 4.8, rankChange: 2 },
-      { id: 2, name: '비빔밥', score: 4.7, rankChange: -1 },
-      { id: 3, name: '돈까스', score: 4.6, rankChange: 1 },
-      { id: 4, name: '된장찌개', score: 4.5, rankChange: 0 },
-      { id: 5, name: '불고기', score: 4.4, rankChange: -2 },
-    ],
-    bottomRankings: [
-      { id: 6, name: '공나물국', score: 2.1, rankChange: -3 },
-      { id: 7, name: '오징어볶음', score: 2.3, rankChange: 1 },
-      { id: 8, name: '김치볶음밥', score: 2.5, rankChange: 0 },
-      { id: 9, name: '우동', score: 2.7, rankChange: 2 },
-      { id: 10, name: '아채죽', score: 2.8, rankChange: -1 },
-    ],
-    period: 'weekly',
-  },
-  monthly: {
-    topRankings: [
-      { id: 1, name: '삼겹살', score: 4.9, rankChange: 3 },
-      { id: 2, name: '치킨', score: 4.8, rankChange: -1 },
-      { id: 3, name: '피자', score: 4.7, rankChange: 2 },
-      { id: 4, name: '라면', score: 4.6, rankChange: -2 },
-      { id: 5, name: '떡볶이', score: 4.5, rankChange: 1 },
-    ],
-    bottomRankings: [
-      { id: 6, name: '청국장', score: 2.0, rankChange: -2 },
-      { id: 7, name: '순대국', score: 2.2, rankChange: 1 },
-      { id: 8, name: '콩나물국밥', score: 2.4, rankChange: 0 },
-      { id: 9, name: '미역국', score: 2.6, rankChange: -1 },
-      { id: 10, name: '북엇국', score: 2.8, rankChange: 2 },
-    ],
-    period: 'monthly',
-  },
-};
-
 export const getMenuRankings = async (period: RankingPeriod): Promise<MenuRankingResponse> => {
-  // const response = await api.get('/api/menuRanking', {
-  //   params: { period },
-  // });
-  // return response.data;
-
-  // 데모 데이터
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(MOCK_DATA[period]);
-    }, 500);
+  const response = await api.get('/api/menu/rank', {
+    params: { period },
   });
+  return response.data;
 };

--- a/src/components/ranking/RankingList.tsx
+++ b/src/components/ranking/RankingList.tsx
@@ -1,84 +1,96 @@
 import React from 'react';
 import styled from 'styled-components';
-import { MenuRankingItem, RankingType } from '../interface/menu';
+import { MenuRankingItem } from '../../interface/menu';
 
 interface RankingListProps {
   title: string;
   items: MenuRankingItem[];
-  type: RankingType;
+  type: 'top' | 'bottom';
 }
 
-const RankingList = ({ title, items, type }: RankingListProps) => {
+const RankingList: React.FC<RankingListProps> = ({ title, items, type }) => {
   return (
-    <RankingSection>
-      <RankingTitle>{title}</RankingTitle>
-      <RankingListContainer>
-        {items.map((item, index) => (
-          <RankingItem key={item.id}>
-            <Rank>{index + 1}</Rank>
-            <MenuName>{item.name}</MenuName>
-            <Score>{item.score.toFixed(1)}점</Score>
-            <RankChange change={item.rankChange}>
-              {item.rankChange > 0
-                ? `▲${item.rankChange}`
-                : item.rankChange < 0
-                  ? `▼${Math.abs(item.rankChange)}`
-                  : '-'}
+    <Container>
+      <Title>{title}</Title>
+      <List>
+        {items.map((item) => (
+          <ListItem key={item.id}>
+            <Rank>{item.rank}</Rank>
+            <Name>{item.name}</Name>
+            <Score>{item.score.toFixed(1)}</Score>
+            <RankChange $change={item.rankChange}>
+              {item.rankChange > 0 ? '↑' : item.rankChange < 0 ? '↓' : '-'}
             </RankChange>
-          </RankingItem>
+          </ListItem>
         ))}
-      </RankingListContainer>
-    </RankingSection>
+      </List>
+    </Container>
   );
 };
 
-const RankingSection = styled.div`
+const Container = styled.div`
   flex: 1;
   min-width: 300px;
-`;
-
-const RankingTitle = styled.h2`
-  font-size: 1.2rem;
-  margin-bottom: 1rem;
-  color: ${(props) => props.theme.colors.primary};
-`;
-
-const RankingListContainer = styled.div`
   background: white;
   border-radius: 12px;
+  padding: 1.5rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
 `;
 
-const RankingItem = styled.div`
+const Title = styled.h2`
+  margin: 0 0 1.5rem 0;
+  color: #333;
+  font-size: 1.5rem;
+`;
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const ListItem = styled.div`
   display: flex;
   align-items: center;
-  padding: 1rem;
-  border-bottom: 1px solid #eee;
-
-  &:last-child {
-    border-bottom: none;
+  padding: 0.75rem;
+  background: #f8f9fa;
+  border-radius: 8px;
+  transition: transform 0.2s;
+  cursor: pointer;
+  &:hover {
+    transform: translateX(4px);
   }
 `;
 
-const Rank = styled.span`
+const Rank = styled.div`
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #e9ecef;
+  border-radius: 50%;
+  margin-right: 1rem;
   font-weight: bold;
-  width: 40px;
 `;
 
-const MenuName = styled.span`
+const Name = styled.div`
   flex: 1;
+  font-weight: 500;
 `;
 
-const Score = styled.span`
+const Score = styled.div`
   margin: 0 1rem;
   color: #666;
 `;
 
-const RankChange = styled.span<{ change: number }>`
-  color: ${(props) => (props.change > 0 ? '#f00' : props.change < 0 ? '#00f' : '#666')};
-  width: 50px;
-  text-align: right;
+const RankChange = styled.div<{ $change: number }>`
+  color: ${({ $change }) => {
+    if ($change > 0) return '#28a745';
+    if ($change < 0) return '#dc3545';
+    return '#6c757d';
+  }};
+  font-weight: bold;
 `;
 
 export default RankingList;

--- a/src/interface/menu.ts
+++ b/src/interface/menu.ts
@@ -2,15 +2,22 @@ export interface MenuRankingItem {
   id: number;
   name: string;
   score: number;
-  rankChange: number; // 순위 변동
+  rankChange: number;
+  rank: number;
 }
 
-export type RankingPeriod = 'weekly' | 'monthly';
+export type RankingPeriod = 'WEEKLY' | 'MONTHLY';
 
-export type RankingType = 'top' | 'bottom';
-
-export interface MenuRankingResponse {
-  topRankings: MenuRankingItem[];
-  bottomRankings: MenuRankingItem[];
-  period: RankingPeriod;
+export interface MenuRankingData {
+  topRankMenuResponse: MenuRankingItem[];
+  bottomRankMenuResponse: MenuRankingItem[];
 }
+
+export interface ApiResponse<T> {
+  httpStatusCode: number;
+  message: string;
+  data: T;
+  resultType: string;
+}
+
+export interface MenuRankingResponse extends ApiResponse<MenuRankingData> {}

--- a/src/pages/MenuRanking.tsx
+++ b/src/pages/MenuRanking.tsx
@@ -5,7 +5,7 @@ import { MenuRankingItem, RankingPeriod } from '../interface/menu';
 import RankingList from '../components/ranking/RankingList';
 
 const MenuRanking = () => {
-  const [period, setPeriod] = useState<RankingPeriod>('weekly');
+  const [period, setPeriod] = useState<RankingPeriod>('WEEKLY');
   const [topRankings, setTopRankings] = useState<MenuRankingItem[]>([]);
   const [bottomRankings, setBottomRankings] = useState<MenuRankingItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -15,8 +15,8 @@ const MenuRanking = () => {
       setLoading(true);
       try {
         const response = await getMenuRankings(period);
-        setTopRankings(response.topRankings);
-        setBottomRankings(response.bottomRankings);
+        setTopRankings(response.data.topRankMenuResponse);
+        setBottomRankings(response.data.bottomRankMenuResponse);
       } catch (error) {
         console.error('랭킹 데이터를 불러오는데 실패했습니다:', error);
       } finally {
@@ -32,10 +32,10 @@ const MenuRanking = () => {
       <RankingHeader>
         <h1>메뉴 랭킹</h1>
         <PeriodToggle>
-          <ToggleButton active={period === 'weekly'} onClick={() => setPeriod('weekly')}>
+          <ToggleButton $active={period === 'WEEKLY'} onClick={() => setPeriod('WEEKLY')}>
             주간
           </ToggleButton>
-          <ToggleButton active={period === 'monthly'} onClick={() => setPeriod('monthly')}>
+          <ToggleButton $active={period === 'MONTHLY'} onClick={() => setPeriod('MONTHLY')}>
             월간
           </ToggleButton>
         </PeriodToggle>
@@ -73,14 +73,14 @@ const PeriodToggle = styled.div`
   padding: 4px;
 `;
 
-const ToggleButton = styled.button<{ active: boolean }>`
+const ToggleButton = styled.button<{ $active: boolean }>`
   padding: 8px 16px;
   border-radius: 16px;
   border: none;
-  background: ${(props) => (props.active ? '#fff' : 'transparent')};
+  background: ${(props) => (props.$active ? '#fff' : 'transparent')};
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: ${(props) => (props.active ? '0 2px 4px rgba(0,0,0,0.1)' : 'none')};
+  box-shadow: ${(props) => (props.$active ? '0 2px 4px rgba(0,0,0,0.1)' : 'none')};
 `;
 
 const RankingsContainer = styled.div`


### PR DESCRIPTION
### 📝작업 내용

> 데모데이터 삭제 후 /api/menu/rank api 연결
- 기존에 구현했던 menuService.ts를 데모데이터를 삭제하고 api 연결
- api 응답 형식에 맞게 menu.ts 수정
- 랭킹 데이터 구조를 topRankMenuReponse, bottomRankMenuResponse로 수정

### 🔨테스트 결과 > 스크린샷 (선택)

<img width="1440" alt="스크린샷 2025-03-30 오전 11 10 25" src="https://github.com/user-attachments/assets/0598e73d-eb2a-4039-802b-290dc079162e" />
